### PR TITLE
feat: add tag component

### DIFF
--- a/src/app/components/Tag.tsx
+++ b/src/app/components/Tag.tsx
@@ -1,0 +1,54 @@
+import React from 'react'
+import { cn } from '~/lib/utils'
+
+interface TagProps {
+  variant:
+    | 'success'
+    | 'warning'
+    | 'danger'
+    | 'lilac'
+    | 'purple'
+    | 'teal'
+    | 'pink'
+    | 'blue'
+    | 'neutral'
+  text: string
+  className?: string
+}
+
+function getTagStyling(variant: string) {
+  switch (variant) {
+    case 'success':
+      return 'bg-green-300 text-green-800 border-green-500'
+    case 'warning':
+      return 'bg-yellow-300 text-yellow-800 border-yellow-500'
+    case 'danger':
+      return 'bg-red-300 text-red-800 border-red-500'
+    case 'lilac':
+      return 'bg-lilac-300 text-lilac-800 border-lilac-500'
+    case 'purple':
+      return 'bg-purple-300 text-white border-purple-500'
+    case 'teal':
+      return 'bg-teal-100 text-teal-600 border-teal-500'
+    case 'pink':
+      return 'bg-pink-100 text-pink-500 border-pink-300'
+    case 'blue':
+      return 'bg-blue-100 text-blue-500 border-blue-300'
+    case 'neutral':
+      return 'bg-neutral-100 text-650-800 border-neutral-300'
+  }
+}
+
+function Tag({ variant, text, className }: TagProps) {
+  const tagClass =
+    getTagStyling(variant) +
+    ' border-4 border-solid flex w-full items-center justify-center py-1 px-1 text-sm md:text-base lg:text-lg min-w-[110px]'
+
+  return (
+    <div className={cn(tagClass, 'rounded-[25px]', className)}>
+      <p className="font-dmsans leading-snug">{text}</p>
+    </div>
+  )
+}
+
+export default Tag


### PR DESCRIPTION
Tag component sesuai di Figma.

Ukuran width dari tag menyesuaikan dengan ukuran parent container nya

## Example
![image](https://github.com/user-attachments/assets/9a021733-85e8-4a75-92d0-63908a823222)
